### PR TITLE
Dataloader refactoring strategy

### DIFF
--- a/example/grid_search/gs_config.yml
+++ b/example/grid_search/gs_config.yml
@@ -51,7 +51,7 @@ data_collator:
 
 data_loaders:
   component_type_key: DATA_LOADER
-  variant_key: DEFAULT
+  variant_key: FUTURE
   requirements:
     - name: iterators
       component_name: splitted_dataset_iterators
@@ -60,7 +60,16 @@ data_loaders:
       component_name: data_collator
   config:
     batch_size: 50
-    weigthed_sampling_split_name: null
+    sampling_strategies:
+      train: 
+        strategy: WEIGHTED_RANDOM
+        seed: 10
+      val: 
+        strategy: IN_ORDER
+        seed: 10
+      test: 
+        strategy: RANDOM
+        seed: 10
 
 model_registry:
   component_type_key: MODEL_REGISTRY

--- a/pytest/data_handling/test_dataset_loader.py
+++ b/pytest/data_handling/test_dataset_loader.py
@@ -41,14 +41,36 @@ class TestSamplerFactory:
         assert sample_weights[100] * 200 == 1
         assert sample_weights[300] * 300 == 1
 
-    def test_split_data_loaders(self, iterator_train: InformedDatasetIteratorIF, iterator_test: InformedDatasetIteratorIF):
+    def test_split_data_loaders(self, iterator_train: InformedDatasetIteratorIF):
         torch.manual_seed(0)
-        iterator_dict = {"train": iterator_train, "test": iterator_test}
-        splitted_data_loaders = DatasetLoaderFactory.get_splitted_data_loaders(
-            iterator_dict, batch_size=1, collate_fn=None, weigthed_sampling_split_name="train", label_pos=0)
-        train_samples = [int(i[0]) for i in splitted_data_loaders["train"]]
-        test_samples = [int(i[0]) for i in splitted_data_loaders["test"]]
-        assert len(train_samples) == len(iterator_train)
-        assert len(test_samples) == len(iterator_test)
-        assert Counter(train_samples) == {2: 218, 3: 192, 1: 190}
-        assert Counter(test_samples) == {2: 20, 3: 30, 1: 10}
+        iterator_dict = {"random_split": iterator_train, "weighted_random_split": iterator_train, "in_order_split": iterator_train}
+        sampling_strategies = {"random_split": {"strategy": "RANDOM", "seed": 10},
+                               "weighted_random_split": {"strategy": "WEIGHTED_RANDOM", "seed": 15, "label_pos": 0},
+                               "in_order_split": {"strategy": "IN_ORDER", "seed": 10}
+                               }
+        splitted_data_loaders = DatasetLoaderFactory.get_splitted_data_loaders(dataset_splits=iterator_dict,
+                                                                               batch_size=1,
+                                                                               collate_fn=None,
+                                                                               sampling_strategies=sampling_strategies)
+        
+        # iterate through all dataloaders 
+        random_samples = [int(i[0]) for i in splitted_data_loaders["random_split"]]
+        weighted_samples = [int(i[0]) for i in splitted_data_loaders["weighted_random_split"]]
+        in_order_samples = [int(i[0]) for i in splitted_data_loaders["in_order_split"]]
+
+        # make sure the number of samples matches the iterator length
+        assert len(random_samples) == len(iterator_train)
+        assert len(weighted_samples) == len(iterator_train)
+        assert len(in_order_samples) == len(iterator_train)
+
+        iterator_samples = [i[0] for i in iterator_train]
+        # make sure the in_order split is actually in order
+        assert in_order_samples == iterator_samples
+        # make sure that random sampler is not in order
+        assert random_samples != iterator_samples
+        # only the order should be different but not the number of samples (we don't resample, we just shuffle the order)
+        assert Counter(random_samples) == {2: 200, 3: 300, 1: 100}
+        # make sure that the each class has the same probability of being drawn
+        assert Counter(weighted_samples) == {3: 212, 2: 201, 1: 187}
+        
+

--- a/src/ml_gym/blueprints/blue_prints.py
+++ b/src/ml_gym/blueprints/blue_prints.py
@@ -29,11 +29,12 @@ class BluePrint(ABC):
         raise NotImplementedError
 
     def get_experiment_info(self) -> ExperimentInfo:
-        experiment_info = DashifyLogger.create_new_experiment(log_dir=self.dashify_logging_dir,
-                                                              subfolder_id=self.grid_search_id,
-                                                              model_name=self.model_name,
-                                                              dataset_name=self.dataset_name,
-                                                              run_id=self.run_id)
+        experiment_info = DashifyLogger.get_experiment_info(log_dir=self.dashify_logging_dir,
+                                                            subfolder_id=self.grid_search_id,
+                                                            model_name=self.model_name,
+                                                            dataset_name=self.dataset_name,
+                                                            run_id=self.run_id)
+        DashifyLogger.save_experiment_info(experiment_info)
         DashifyLogger.save_config(config=self.config, experiment_info=experiment_info)
         return experiment_info
 

--- a/src/ml_gym/blueprints/component_factory.py
+++ b/src/ml_gym/blueprints/component_factory.py
@@ -1,10 +1,10 @@
 import copy
-from typing import Dict, Any, List, Optional, Type, Union
+from typing import Dict, Any, List, Type, Union
 from collections import namedtuple
 from dataclasses import dataclass, field
 from ml_gym.error_handling.exception import ComponentConstructionError, InjectMappingNotFoundError, DependentComponentNotFoundError
 from ml_gym.blueprints.constructables import ComponentConstructable, DatasetIteratorConstructable, \
-    DatasetIteratorSplitsConstructable, Requirement, DataLoadersConstructable, DatasetRepositoryConstructable, \
+    DatasetIteratorSplitsConstructable, DeprecatedDataLoadersConstructable, Requirement, DataLoadersConstructable, DatasetRepositoryConstructable, \
     OptimizerConstructable, ModelRegistryConstructable, ModelConstructable, LossFunctionRegistryConstructable, \
     MetricFunctionRegistryConstructable, TrainerConstructable, EvaluatorConstructable, MappedLabelsIteratorConstructable, \
     FilteredLabelsIteratorConstructable, FeatureEncodedIteratorConstructable, CombinedDatasetIteratorConstructable, \
@@ -92,7 +92,7 @@ class ComponentFactory:
 
             try:
                 constructable = self.constructables[variant_key]
-                component = constructable(component_identifier=component_name, requirements=requirements, **config).construct()
+                component = constructable(component_identifier=component_name, requirements=requirements, **copy.deepcopy(config)).construct()
             except Exception as e:
                 raise ComponentConstructionError(f"Error during component creation from {constructable}") from e
             return component
@@ -119,7 +119,8 @@ class ComponentFactory:
             ComponentVariant("MAPPED_LABELS_ITERATOR", "DEFAULT", MappedLabelsIteratorConstructable),
             ComponentVariant("DATA_COLLATOR", "DEFAULT", DataCollatorConstructable),
             ComponentVariant("FEATURE_ENCODED_ITERATORS", "DEFAULT", FeatureEncodedIteratorConstructable),
-            ComponentVariant("DATA_LOADER", "DEFAULT", DataLoadersConstructable),
+            ComponentVariant("DATA_LOADER", "DEFAULT", DeprecatedDataLoadersConstructable),
+            ComponentVariant("DATA_LOADER", "FUTURE", DataLoadersConstructable),
             ComponentVariant("OPTIMIZER", "DEFAULT", OptimizerConstructable),
             ComponentVariant("MODEL_REGISTRY", "DEFAULT", ModelRegistryConstructable),
             ComponentVariant("LOSS_FUNCTION_REGISTRY", "DEFAULT", LossFunctionRegistryConstructable),

--- a/src/ml_gym/data_handling/dataset_loader.py
+++ b/src/ml_gym/data_handling/dataset_loader.py
@@ -1,18 +1,21 @@
+from ml_gym.error_handling.exception import SamplerNotFoundError
 from torch.utils.data import DataLoader
 from torch.utils.data.sampler import RandomSampler, WeightedRandomSampler
-from typing import Callable, Dict, List
+from typing import Callable, Dict, Any
 from data_stack.dataset.iterator import InformedDatasetIteratorIF
 from torch.utils.data.sampler import Sampler
 from collections import Counter
 import torch
 from ml_gym.data_handling.postprocessors.collator import Collator
+from enum import Enum
 
 
 class DatasetLoaderFactory:
+
     @staticmethod
-    def get_splitted_data_loaders(dataset_splits: Dict[str, InformedDatasetIteratorIF], batch_size: int, collate_fn: Callable = None,
-                                  weigthed_sampling_split_name: str = None, label_pos: int = 2, seeds: Dict[str, int] = None,
-                                  drop_last: bool = False) -> Dict[str, "DatasetLoader"]:
+    def get_splitted_data_loaders_deprecated(dataset_splits: Dict[str, InformedDatasetIteratorIF], batch_size: int, collate_fn: Callable = None,
+                                             weigthed_sampling_split_name: str = None, label_pos: int = 2, seeds: Dict[str, int] = None,
+                                             drop_last: bool = False) -> Dict[str, "DatasetLoader"]:
         seeds = {} if seeds is None else seeds
         # NOTE: Weighting is only applied to the split specified by `weigthed_sampling_split_name`.
         data_loaders = {}
@@ -30,8 +33,39 @@ class DatasetLoaderFactory:
                                                      drop_last=drop_last)
         return data_loaders
 
+    @staticmethod
+    def get_splitted_data_loaders(dataset_splits: Dict[str, InformedDatasetIteratorIF], batch_size: int, collate_fn: Callable = None,
+                                  drop_last: bool = False, sampling_strategies: Dict[str, Any] = None) -> Dict[str, "DatasetLoader"]:
+        data_loaders = {}
+        for split_id, (split_name, dataset_split) in enumerate(dataset_splits.items()):
+            if split_name in sampling_strategies:
+                config = sampling_strategies[split_name]
+                strategy = SamplerFactory.SamplingStrategies[sampling_strategies[split_name]["strategy"]]
+                config.pop("strategy")
+                if strategy == SamplerFactory.SamplingStrategies.WEIGHTED_RANDOM:
+                    sampler = SamplerFactory.get_weighted_sampler(dataset_split, **config)
+                elif strategy == SamplerFactory.SamplingStrategies.RANDOM:
+                    sampler = SamplerFactory.get_random_sampler(dataset_split, **config)
+                elif strategy == SamplerFactory.SamplingStrategies.IN_ORDER:
+                    sampler = None
+                else:
+                    raise SamplerNotFoundError(f"Could not find sampler with key {strategy}")
+            else:
+                sampler = None
+            data_loaders[split_name] = DatasetLoader(dataset_iterator=dataset_split,
+                                                     batch_size=batch_size,
+                                                     sampler=sampler,
+                                                     collate_fn=collate_fn,
+                                                     drop_last=drop_last)
+        return data_loaders
+
 
 class SamplerFactory:
+
+    class SamplingStrategies(Enum):
+        RANDOM = "random"
+        WEIGHTED_RANDOM = "weighted_random"
+        IN_ORDER = "in_order"
 
     @staticmethod
     def get_weighted_sampler(dataset: InformedDatasetIteratorIF, label_pos: int = 2, seed: int = 0) -> Sampler:
@@ -44,7 +78,7 @@ class SamplerFactory:
         Returns:
             [WeightedRandomSampler]: Instance of WeightedRandomSampler.
         """
-        rnd_generator = torch.Generator().manual_seed(seed) if seed is not None  else None
+        rnd_generator = torch.Generator().manual_seed(seed) if seed is not None else None
         # get the class weights
         target_counts = Counter([int(sample[label_pos]) for sample in dataset])  # uses generator expression
         target_tuples = [(k, v) for k, v in sorted(target_counts.items(), key=lambda item: item[0])]
@@ -55,12 +89,12 @@ class SamplerFactory:
 
     @staticmethod
     def get_random_sampler(dataset: InformedDatasetIteratorIF, seed: int = 0) -> Sampler:
-        rnd_generator = torch.Generator().manual_seed(seed) if seed is not None  else None
+        rnd_generator = torch.Generator().manual_seed(seed) if seed is not None else None
         return RandomSampler(data_source=dataset, generator=rnd_generator)
 
 
 class DatasetLoader(DataLoader):
-    def __init__(self, dataset_iterator: InformedDatasetIteratorIF, batch_size: int, sampler: Sampler, 
+    def __init__(self, dataset_iterator: InformedDatasetIteratorIF, batch_size: int, sampler: Sampler,
                  collate_fn: Collator = None, drop_last: bool = False):
         super().__init__(dataset=dataset_iterator, sampler=sampler, batch_size=batch_size, collate_fn=collate_fn, drop_last=drop_last)
 

--- a/src/ml_gym/error_handling/exception.py
+++ b/src/ml_gym/error_handling/exception.py
@@ -74,3 +74,8 @@ class InvalidTensorFormatError(Exception):
 class OptimizerNotInitializedError(Exception):
     """Raised when we want to run an operation on an optimizer, which was not instantiated, yet."""
     pass
+
+
+class SamplerNotFoundError(Exception):
+    """Raised when the sampler implemenation for a given datsetloader was not found."""
+    pass


### PR DESCRIPTION
Previously the dataloader implementation was always using a random sampler.
When we evaluate a model e.g., within a jupyter notebook, we need a dataloader that iterates through the dataloader in the original order such that targets and inputs can be easily matched.

Therefore, I introduced different sampling strategies that are configurable via the config file. 