### PR TITLE
Chunked checkpointing

### DIFF
--- a/src/ml_board/README.md
+++ b/src/ml_board/README.md
@@ -225,12 +225,11 @@ Create checkpoint:
     "payload": {
         "grid_search_id": <timestamp>, 
         "experiment_id": <int>,
-        "checkpoint_id": <str>,
-        "checkpoint_streams":{
-            "model": <model as binary stream>,
-            "optimizer": <optimizer as binary stream>,
-            "stateful_components": <stateful components as byte stream>
-        }
+        "checkpoint_id": <int>, # epoch
+        "entity_id": <str> # <model, optimizer, stateful_components>
+        "chunk_data": <chunk of binary stream>,
+        "chunk_id": <int> # id identifying the chunk,
+        "final_num_chunks": <int> # 
     }
 }
 ```
@@ -247,12 +246,11 @@ Delete checkpoint:
     "payload": {
         "grid_search_id": <timestamp>, 
         "experiment_id": <int>,
-        "checkpoint_id": <str>,
-        "checkpoint_streams":{
-            "model": None,
-            "optimizer": None,
-            "stateful_components": None
-        }
+        "checkpoint_id": <int>, # epoch
+        "entity_id": <str> # <model, optimizer, stateful_components>
+        "chunk_data": None,
+        "chunk_id": -1,
+        "final_num_chunks": 0 
     }
 }
 ```

--- a/src/ml_board/backend/websocket_api/checkpoint_cache.py
+++ b/src/ml_board/backend/websocket_api/checkpoint_cache.py
@@ -1,0 +1,79 @@
+from typing import List, Dict
+from enum import Enum
+import os
+
+from ml_gym.error_handling.exception import CheckpointEntityError
+
+
+class CheckpointEntityTransferStatus(Enum):
+
+    TRANSFERRING = "TRANSFERRING"
+    TRANSFERRED = "TRANSFERRED"
+    DELETED = "DELETED"
+
+
+class CheckpointEntity:
+
+    def __init__(self, grid_search_id: str, experiment_id: int, checkpoint_id: int, entity_id: str, final_num_chunks: int):
+        self.grid_search_id = grid_search_id
+        self.experiment_id = experiment_id
+        self.checkpoint_id = checkpoint_id
+        self.entity_id = entity_id
+        self._chunks: List[bytes] = [None]*final_num_chunks  # chunk_id -> bytes object
+
+    def get_transfer_status(self) -> CheckpointEntityTransferStatus:
+        if self._chunks is None:
+            return CheckpointEntityTransferStatus.DELETED
+
+        for chunk in self._chunks[::-1]:
+            if chunk is None:
+                return CheckpointEntityTransferStatus.TRANSFERRING
+
+        return CheckpointEntityTransferStatus.TRANSFERRED
+
+    def add_chunk(self, chunk_id: int, chunk_data: bytes) -> "CheckpointEntity":
+        self._chunks[chunk_id] = chunk_data
+        return self
+
+    def get_chunk_list(self) -> List[bytes]:
+        return self._chunks
+
+    def delete_chunks(self):
+        self._chunks = None
+
+
+class CheckpointCache:
+
+    def __init__(self):
+        # grid_search_id/experiment_id/checkpoint_id (epoch)/entity_id (e.g. model) -> {chunk_id -> stream_chunk, status=<DELETED, >}
+        self._checkpoint_dict: Dict[str, CheckpointEntity] = {}  # TODO make this thread-safe
+
+    def add_chunk(self, grid_search_id: str, experiment_id: str, checkpoint_id: int, entity_id: str,
+                  chunk_id: int, chunk_data: bytes, final_num_chunks: int) -> CheckpointEntity:
+        full_key = os.path.join(grid_search_id, str(experiment_id), str(checkpoint_id), str(entity_id))
+        if full_key not in self._checkpoint_dict:
+            entity = CheckpointEntity(grid_search_id=grid_search_id,
+                                      experiment_id=experiment_id,
+                                      checkpoint_id=checkpoint_id,
+                                      entity_id=entity_id,
+                                      final_num_chunks=final_num_chunks)
+            self._checkpoint_dict[full_key] = entity
+
+        entity = self._checkpoint_dict[full_key]
+        if entity.get_transfer_status() == CheckpointEntityTransferStatus.TRANSFERRING:
+            entity.add_chunk(chunk_id=chunk_id, chunk_data=chunk_data)
+            return entity
+        else:
+            raise CheckpointEntityError(f"Cannot add chunk to entitity. CheckpointEntityTransferStatus is {entity.get_transfer_status()}")
+
+    def delete_entity(self, grid_search_id: str, experiment_id: str, checkpoint_id: int, entity_id: str,
+                      chunk_id: int, chunk_data: bytes, final_num_chunks: int):
+
+        full_key = os.path.join(grid_search_id, str(experiment_id), str(checkpoint_id), str(entity_id))
+        if full_key in self._checkpoint_dict:
+            entity = self._checkpoint_dict[full_key]
+            entity.delete_chunks()
+            print(f"Deleted {full_key}")
+
+        else:
+            raise CheckpointEntityError(f"Cannot delete checkpoint entity. Key {full_key} not present.")

--- a/src/ml_gym/checkpointing/checkpointing.py
+++ b/src/ml_gym/checkpointing/checkpointing.py
@@ -34,7 +34,8 @@ class SaveLastEpochOnlyCheckpointingStrategy(CheckpointingIF):
 
     def get_model_checkpoint_instruction(self, current_epoch: int, num_epochs: int,
                                          evaluation_result: EvaluationBatchResult) -> CheckpointingInstruction:
-        return CheckpointingInstruction(save_current=True, checkpoints_to_delete=[current_epoch-1])
+        checkpoints_to_delete = [current_epoch-1] if current_epoch > 0 else []
+        return CheckpointingInstruction(save_current=True, checkpoints_to_delete=checkpoints_to_delete)
 
 
 class SaveAllCheckpointingStrategy(CheckpointingIF):

--- a/src/ml_gym/error_handling/exception.py
+++ b/src/ml_gym/error_handling/exception.py
@@ -119,3 +119,8 @@ class DataIntegrityError(Exception):
 class InvalidPathError(Exception):
     """Raised when the path to a file or directory is invalid/corrupt."""
     pass
+
+
+class CheckpointEntityError(Exception):
+    """Raised when there is an error within the checkpoint entity."""
+    pass

--- a/src/ml_gym/gym/jobs.py
+++ b/src/ml_gym/gym/jobs.py
@@ -118,11 +118,16 @@ class GymJob(AbstractGymJob):
 
     def run_checkpointing(self, checkpoint_instruction: CheckpointingInstruction):
         if checkpoint_instruction.save_current:
-            self._experiment_status_logger.log_checkpoint(self.current_epoch, self.model.state_dict(), self.optimizer.state_dict(),
-                                                          self.get_state())
+            self._experiment_status_logger.log_checkpoint(epoch=self.current_epoch,
+                                                          model_state_dict=self.model.state_dict(),
+                                                          optimizer_state_dict=self.optimizer.state_dict(),
+                                                          stateful_components_state_dict=self.get_state())
         for epoch in checkpoint_instruction.checkpoints_to_delete:
-            self._experiment_status_logger.log_checkpoint(epoch=epoch, model_binary_stream=None,
-                                                          optimizer_binary_stream=None, stateful_components_binary_stream=None)
+            print(f"epoch to delete: {epoch}")
+            self._experiment_status_logger.log_checkpoint(epoch=epoch,
+                                                          model_state_dict=None,
+                                                          optimizer_state_dict=None,
+                                                          stateful_components_state_dict=None)
 
     def execute(self, device: torch.device):
         """ Executes the job

--- a/src/ml_gym/io/websocket_client.py
+++ b/src/ml_gym/io/websocket_client.py
@@ -34,7 +34,8 @@ class BufferedClient:
         sio_client.on("mlgym_event", BufferedClient.on_mlgym_event_message)
 
     def connect(self):
-        self._sio_client.connect(f"{self._host}:{self._port}", wait=True, wait_timeout=20)
+        self._sio_client.connect(f"{self._host}:{self._port}", wait=True, wait_timeout=20, transports="websocket")
+        print(f"Connected to {self._host}:{self._port} with transport protocol {self._sio_client.transport()}")
         BufferedClient._register_callback_funs(self._sio_client)
         self.emit("join", {"client_id": self._client_id, "rooms": [*self.rooms, self._client_id]})
 
@@ -52,4 +53,3 @@ class BufferedClient:
     def emit(self, message_key: str,  message: Dict):
         self._sio_client.emit(message_key, message)
         # print(f"Sent message {message_key}: {message}")
-

--- a/src/ml_gym/starter.py
+++ b/src/ml_gym/starter.py
@@ -17,7 +17,7 @@ class MLGymStarter:
     @staticmethod
     def _create_gym(job_id_prefix: str, process_count: int, device_ids, log_std_to_file: bool,
                     logger_collection_constructable: MLgymStatusLoggerCollectionConstructable) -> Gym:
-        gym = Gym(job_id_prefix, process_count, device_ids=device_ids, log_std_to_file=log_std_to_file,
+        gym = Gym(job_id_prefix=job_id_prefix, process_count=process_count, device_ids=device_ids, log_std_to_file=log_std_to_file,
                   logger_collection_constructable=logger_collection_constructable)
         return gym
 


### PR DESCRIPTION
Before checkpointing entities such as models or optimizers we now chunk them into 1MB chunks to prevent overflowing the network stream with a single message. 

Currently, we wrap the websocket server within Flask which creates some network bottlenecks. We could think about upgrading to e.g., eventlet. 

https://stackoverflow.com/questions/48661706/flask-socketio-is-too-slow

https://python-socketio.readthedocs.io/en/latest/server.html#eventlet 

