### PR TITLE
Deepspeed zero stage 3 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ event_storage
 *.whl
 *.arrow
 transformer/
+core.*

--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,3 @@ event_storage
 *.whl
 *.arrow
 transformer/
-

--- a/example/bert/run.py
+++ b/example/bert/run.py
@@ -1,4 +1,3 @@
-
 from bert_lm_blueprint import BERTLMBluePrint
 from ml_gym.cmd_entrypoint.cmd import get_args, run
 

--- a/example/cnn_ddp/conv_net.py
+++ b/example/cnn_ddp/conv_net.py
@@ -41,10 +41,13 @@ class ConvNet(NNModel):
         output = F.dropout(output, p=0.25, training=True)
 
         output = output.view(inputs.shape[0], -1)
-        output = self.fc_layers[0](output)
-        output = F.relu(output)
-        output = F.dropout(output, p=0.5, training=True)
-        output = self.fc_layers[1](output)
+
+        for layer in self.fc_layers[:-1]:
+            output = layer(output)
+            output = F.relu(output)
+            output = F.dropout(output, p=0.5, training=True)
+
+        output = self.fc_layers[-1](output)
 
         return {self.prediction_publication_key: output}
 

--- a/example/cnn_ddp/train_cnn_accelerate.sh
+++ b/example/cnn_ddp/train_cnn_accelerate.sh
@@ -2,4 +2,5 @@
 #!/bin/sh
 
 
-accelerate launch --multi_gpu --num_processes=8 --gpu_ids 0,1,2,3,4,5,6,7 run.py --config_path /scratch/max/mlgym/example/cnn_ddp/run_config.yml
+accelerate launch --multi_gpu --gpu_ids "0,1,3" --num_processes=3  \
+                /scratch/max/mlgym/example/cnn_ddp/run.py --config_path /scratch/max/mlgym/example/cnn_ddp/run_config.yml

--- a/example/cnn_zero_stage_3/ac_config.yaml
+++ b/example/cnn_zero_stage_3/ac_config.yaml
@@ -1,0 +1,18 @@
+compute_environment: LOCAL_MACHINE
+deepspeed_config:
+  deepspeed_config_file: /scratch/max/mlgym/example/cnn_zero_stage_3/ds_config.json
+  zero3_init_flag: true
+distributed_type: DEEPSPEED
+downcast_bf16: "no"
+dynamo_backend: "NO"
+fsdp_config: {}
+machine_rank: 0
+main_training_function: main
+megatron_lm_config: {}
+num_machines: 1
+num_processes: 2
+rdzv_backend: static
+same_network: true
+use_cpu: false
+gpu_ids: "0,1"
+

--- a/example/cnn_zero_stage_3/cnn_experiment_config.yml
+++ b/example/cnn_zero_stage_3/cnn_experiment_config.yml
@@ -1,0 +1,267 @@
+global_config:
+  storage_connector_path: &storage_path_anchor ./file_storage/
+  seed: &seed_value 2
+  target_key: &target_key_anchor target_key
+  model_prediction_key: &model_prediction_key_anchor model_prediction_key
+  postprocessing_argmax_key: &postprocessing_argmax_key_anchor postprocessing_argmax_key
+
+dataset_repository:
+  component_type_key: DATASET_REPOSITORY
+  variant_key: DEFAULT
+  config:
+    storage_connector_path: *storage_path_anchor
+
+dataset_iterators:
+  component_type_key: DATASET_ITERATORS
+  variant_key: DEFAULT
+  requirements:
+    - name: repository
+      component_name: dataset_repository
+  config:
+    dataset_identifier: mnist
+    split_configs:
+      - split: train
+      - split: test
+
+splitted_dataset_iterators:
+  component_type_key: SPLITTED_DATASET_ITERATORS
+  variant_key: RANDOM
+  requirements:
+    - name: iterators
+      component_name: dataset_iterators
+      subscription:
+        - train
+        - test
+  config:
+    split_configs:
+      train:
+        train: 0.7
+        val: 0.3
+    seed: 2
+
+data_collator:
+  component_type_key: DATA_COLLATOR
+  variant_key: DEFAULT
+  config:
+    collator_type:
+      injectable:
+        id: id_conv_mnist_standard_collator
+    collator_params:
+      target_publication_key: *target_key_anchor
+
+data_loaders:
+  component_type_key: DATA_LOADER
+  variant_key: DEFAULT
+  requirements:
+    - name: iterators
+      component_name: splitted_dataset_iterators
+      subscription: [train, val, test]
+    - name: data_collator
+      component_name: data_collator
+  config:
+    batch_size: 100
+    weigthed_sampling_split_name: train
+    seeds:
+      train: 0
+      val: 1
+      test: 2
+
+model_registry:
+  component_type_key: MODEL_REGISTRY
+  variant_key: DEFAULT
+
+model:
+  component_type_key: MODEL
+  variant_key: DEFAULT
+  requirements:
+    - name: model_registry
+      component_name: model_registry
+      subscription: conv_net
+  config:
+    model_definition:
+      layer_config:
+        - params:
+            in_channels: 1
+            kernel_size: 3
+            out_channels: 32
+            stride: 1
+          type: conv
+        - params:
+            in_channels: 32
+            kernel_size: 3
+            out_channels: 64
+            stride: 1
+          type: conv
+        - params:
+            in_features: 9216
+            out_features: 128
+          type: fc
+        - params:
+            in_features: 128
+            out_features: 30000
+          type: fc
+        # - params:
+        #     in_features: 30000
+        #     out_features: 30000
+        #   type: fc
+        # - params:
+        #     in_features: 30000
+        #     out_features: 30000
+        #   type: fc
+        # - params:
+        #     in_features: 30000
+        #     out_features: 30000
+        #   type: fc
+        - params:
+            in_features: 30000
+            out_features: 10
+          type: fc
+    prediction_publication_keys:
+      prediction_publication_key: *model_prediction_key_anchor
+    seed: *seed_value
+
+optimizer:
+  component_type_key: OPTIMIZER
+  variant_key: DEFAULT
+  config:
+    optimizer_key: ADAM
+    params:
+      lr: 
+        sweep: absolute
+        values: [0.001] # [1, 0.1, 0.01, 0.001, 0.0001]
+
+lr_scheduler:
+  component_type_key: LR_SCHEDULER
+  variant_key: DEFAULT
+  config:
+    lr_scheduler_key: dummy
+
+loss_function_registry:
+  component_type_key: LOSS_FUNCTION_REGISTRY
+  variant_key: DEFAULT
+
+metric_registry:
+  component_type_key: METRIC_REGISTRY
+  variant_key: DEFAULT
+
+prediction_postprocessing_registry:
+  component_type_key: PREDICTION_POSTPROCESSING_REGISTRY
+  variant_key: DEFAULT
+
+train_component:
+  component_type_key: TRAIN_COMPONENT
+  variant_key: ACCELERATE
+  requirements:
+    - name: loss_function_registry
+      component_name: loss_function_registry
+    - name: prediction_postprocessing_registry
+      component_name: prediction_postprocessing_registry
+  config:
+    loss_fun_config:
+      prediction_subscription_key: *model_prediction_key_anchor
+      target_subscription_key: *target_key_anchor
+      key: CrossEntropyLoss
+      tag: cross_entropy_loss
+
+trainer:
+  component_type_key: TRAINER
+  variant_key: ACCELERATE
+  requirements:
+    - name: train_component
+      component_name: train_component
+    - name: model
+      component_name: model
+      subscription: null
+    - name: data_loaders
+      component_name: data_loaders
+      subscription: train
+
+eval_component:
+  component_type_key: EVAL_COMPONENT
+  variant_key: ACCELERATE
+  requirements:
+    - name: model
+      component_name: model
+      subscription: null
+    - name: data_loaders
+      component_name: data_loaders
+      subscription: [train, val, test]
+    - name: loss_function_registry
+      component_name: loss_function_registry
+    - name: metric_registry
+      component_name: metric_registry
+    - name: prediction_postprocessing_registry
+      component_name: prediction_postprocessing_registry
+  config:
+    cpu_target_subscription_keys:
+      - *target_key_anchor
+    cpu_prediction_subscription_keys:
+      - *postprocessing_argmax_key_anchor
+      - *model_prediction_key_anchor
+    post_processors_config:
+      - key: "ARG_MAX"
+        prediction_subscription_key: *model_prediction_key_anchor
+        prediction_publication_key: *postprocessing_argmax_key_anchor
+    metrics_config:
+      - key: F1_SCORE
+        params:
+          average: macro
+        prediction_subscription_key: *postprocessing_argmax_key_anchor
+        target_subscription_key: *target_key_anchor
+        tag: F1_SCORE_macro
+      - key: PRECISION
+        params:
+          average: macro
+        prediction_subscription_key: *postprocessing_argmax_key_anchor
+        target_subscription_key: *target_key_anchor
+        tag: PRECISION_macro
+      - key: RECALL
+        params:
+          average: macro
+        prediction_subscription_key: *postprocessing_argmax_key_anchor
+        target_subscription_key: *target_key_anchor
+        tag: RECALL_macro
+    loss_funs_config:
+      - prediction_subscription_key: *model_prediction_key_anchor
+        target_subscription_key: *target_key_anchor
+        key: CrossEntropyLoss
+        tag: cross_entropy_loss
+
+evaluator:
+  component_type_key: EVALUATOR
+  variant_key: ACCELERATE
+  requirements:
+    - name: eval_component
+      component_name: eval_component
+
+early_stopping_strategy_registry:
+  component_type_key: EARLY_STOPPING_STRATEGY_REGISTRY
+  variant_key: DEFAULT
+
+early_stopping_strategy:
+  component_type_key: EARLY_STOPPING_STRATEGY
+  variant_key: DEFAULT
+  requirements:
+    - name: early_stopping_strategy_registry
+      component_name: early_stopping_strategy_registry
+  config:
+    early_stopping_key: LAST_K_EPOCHS_IMPROVEMENT_STRATEGY
+    early_stopping_config:
+      min_relative_improvement: 0.00001
+      epochs_window: 5
+      split_name: val
+      monitoring_key: "F1_SCORE_macro"
+      is_increase_task: true
+
+checkpointing_strategy_registry:
+  component_type_key: CHECKPOINTING_STRATEGY_REGISTRY
+  variant_key: DEFAULT
+
+checkpointing_strategy:
+  component_type_key: CHECKPOINTING_STRATEGY
+  variant_key: DEFAULT
+  requirements:
+    - name: checkpointing_strategy_registry
+      component_name: checkpointing_strategy_registry
+  config:
+    checkpointing_key: SAVE_LAST_EPOCH_ONLY_CHECKPOINTING_STRATEGY

--- a/example/cnn_zero_stage_3/conv_net.py
+++ b/example/cnn_zero_stage_3/conv_net.py
@@ -31,6 +31,7 @@ class ConvNet(NNModel):
                          out_features=layer_dict["out_features"])
 
     def forward_impl(self, inputs: torch.Tensor) -> Dict[str, torch.Tensor]:
+        # print(f"input shape: {inputs.shape}")
         output = inputs
         output = self.conv_layers[0](output)
         output = F.relu(output)
@@ -41,13 +42,10 @@ class ConvNet(NNModel):
         output = F.dropout(output, p=0.25, training=True)
 
         output = output.view(inputs.shape[0], -1)
-
-        for layer in self.fc_layers[:-1]:
-            output = layer(output)
-            output = F.relu(output)
-            output = F.dropout(output, p=0.5, training=True)
-
-        output = self.fc_layers[-1](output)
+        output = self.fc_layers[0](output)
+        output = F.relu(output)
+        output = F.dropout(output, p=0.5, training=True)
+        output = self.fc_layers[1](output)
 
         return {self.prediction_publication_key: output}
 

--- a/example/cnn_zero_stage_3/conv_net.py
+++ b/example/cnn_zero_stage_3/conv_net.py
@@ -31,7 +31,6 @@ class ConvNet(NNModel):
                          out_features=layer_dict["out_features"])
 
     def forward_impl(self, inputs: torch.Tensor) -> Dict[str, torch.Tensor]:
-        # print(f"input shape: {inputs.shape}")
         output = inputs
         output = self.conv_layers[0](output)
         output = F.relu(output)
@@ -42,10 +41,13 @@ class ConvNet(NNModel):
         output = F.dropout(output, p=0.25, training=True)
 
         output = output.view(inputs.shape[0], -1)
-        output = self.fc_layers[0](output)
-        output = F.relu(output)
-        output = F.dropout(output, p=0.5, training=True)
-        output = self.fc_layers[1](output)
+
+        for layer in self.fc_layers[:-1]:
+            output = layer(output)
+            output = F.relu(output)
+            output = F.dropout(output, p=0.5, training=True)
+
+        output = self.fc_layers[-1](output)
 
         return {self.prediction_publication_key: output}
 

--- a/example/cnn_zero_stage_3/conv_net_blueprint.py
+++ b/example/cnn_zero_stage_3/conv_net_blueprint.py
@@ -1,0 +1,71 @@
+from typing import Dict, List, Any
+from ml_gym.modes import RunMode
+import torch
+from ml_gym.blueprints.constructables import ModelRegistryConstructable
+from ml_gym.blueprints.blue_prints import BluePrint
+from ml_gym.batching.batch import DatasetBatch
+from dataclasses import dataclass
+from ml_gym.blueprints.component_factory import ComponentFactory, Injector
+from ml_gym.data_handling.postprocessors.collator import Collator
+from conv_net import ConvNet
+
+
+@dataclass
+class MNISTCollator(Collator):
+    target_publication_key: str = None
+
+    def __call__(self, batch: List[torch.Tensor]):
+        """
+        :param batch: batch format [no_samples, height, width, channels]
+        :return:
+        """
+        # batch contains a list of tuples of structure (sequence, target)
+        inputs = [item[0].to(self.device) for item in batch]
+        inputs = torch.stack(inputs)
+        # transform into vector
+        # inputs = inputs.view(inputs.shape[0], -1)
+        # transform into CHW matrix
+        # inputs = inputs.permute(0, 3, 1, 2)
+        inputs = inputs.reshape(-1, 1, 28, 28)
+        targets_tensor = torch.tensor([item[1] for item in batch]).to(inputs[0].device)
+        target_partitions = {self.target_publication_key: targets_tensor}
+        return DatasetBatch(targets=target_partitions, tags=None, samples=inputs)
+
+
+@dataclass
+class MyModelRegistryConstructable(ModelRegistryConstructable):
+    def _construct_impl(self):
+        super()._construct_impl()
+        self.model_registry.add_class("conv_net", ConvNet)
+        return self.model_registry
+
+
+class ConvNetBluePrint(BluePrint):
+    def __init__(self, run_mode: RunMode, config: Dict, grid_search_id: str,
+                 experiment_id: str, external_injection: Dict[str, Any] = None, warm_start_epoch: int = 0):
+        super().__init__(run_mode, config, grid_search_id, experiment_id, external_injection, warm_start_epoch)
+
+    @staticmethod
+    def construct_components(config: Dict, component_names: List[str], device: torch.device,
+                             external_injection: Dict[str, Any] = None) -> Dict[str, Any]:
+        if external_injection is not None:
+            injection_mapping = {"id_conv_mnist_standard_collator": MNISTCollator,
+                                 "id_computation_device": device,
+                                 **external_injection}
+            injector = Injector(injection_mapping, raise_mapping_not_found=True)
+
+        else:
+            injection_mapping = {"id_conv_mnist_standard_collator": MNISTCollator}
+            injector = Injector(injection_mapping, raise_mapping_not_found=False)
+
+        component_factory = ComponentFactory(injector)
+        component_factory.register_component_type("MODEL_REGISTRY", "DEFAULT", MyModelRegistryConstructable)
+
+        components = component_factory.build_components_from_config(config, component_names)
+        return components
+
+    def construct(self, device: torch.device = None) -> Dict[str, Any]:
+        component_names = ["model", "trainer", "optimizer", "lr_scheduler", "evaluator", "early_stopping_strategy", "checkpointing_strategy"]
+        components = ConvNetBluePrint.construct_components(self.config, component_names, device, self.external_injection)
+
+        return components

--- a/example/cnn_zero_stage_3/ds_config.json
+++ b/example/cnn_zero_stage_3/ds_config.json
@@ -1,0 +1,20 @@
+{
+    "bf16": {
+        "enabled": false 
+    },
+    "zero_optimization": {
+        "stage": 3,
+        "stage3_gather_16bit_weights_on_model_save": false,
+        "offload_optimizer": {
+            "device": "none"
+        },
+        "offload_param": {
+            "device": "none"
+        }
+    },
+    "gradient_clipping": 1.0,
+    "train_batch_size": "auto",
+    "train_micro_batch_size_per_gpu": "auto",
+    "gradient_accumulation_steps": 1,
+    "steps_per_print": 2000000
+}

--- a/example/cnn_zero_stage_3/ds_test.py
+++ b/example/cnn_zero_stage_3/ds_test.py
@@ -1,0 +1,11 @@
+from accelerate import Accelerator
+from accelerate.state import AcceleratorState
+
+
+def main():
+    accelerator = Accelerator()
+    accelerator.print(f"{AcceleratorState()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/cnn_zero_stage_3/run.py
+++ b/example/cnn_zero_stage_3/run.py
@@ -1,0 +1,8 @@
+
+from conv_net_blueprint import ConvNetBluePrint
+from ml_gym.cmd_entrypoint.cmd import get_args, run
+
+if __name__ == '__main__':
+    blueprint_class = ConvNetBluePrint
+    config_path = get_args()
+    run(blueprint_class=blueprint_class, run_configuration_file_path=config_path)

--- a/example/cnn_zero_stage_3/run_config.yml
+++ b/example/cnn_zero_stage_3/run_config.yml
@@ -1,0 +1,14 @@
+run_configuration:
+  type: train # train, warmstart
+  config:
+    num_epochs: 10 # Number of epochs
+    # num_batches_per_epoch: 100
+    gs_config_path: /scratch/max/mlgym/example/cnn_zero_stage_3/cnn_experiment_config.yml
+
+environment:
+  type: accelerate # multiprocessing,  main_process, accelerate
+
+logging:
+  websocket_logging_servers: # List of websocket logging servers, e.g., http://127.0.0.1:9090 http://127.0.0.1:8080
+    - http://127.0.0.1:5002
+  gs_rest_api_endpoint: http://127.0.0.1:5001 # Endpoint for the grid search API, e.g., http://127.0.0.1:8080

--- a/example/cnn_zero_stage_3/train_cnn_accelerate.sh
+++ b/example/cnn_zero_stage_3/train_cnn_accelerate.sh
@@ -1,0 +1,6 @@
+ 
+#!/bin/sh
+
+
+accelerate launch --config_file /scratch/max/mlgym/example/cnn_zero_stage_3/ac_config.yaml \
+                /scratch/max/mlgym/example/cnn_zero_stage_3/run.py --config_path /scratch/max/mlgym/example/cnn_zero_stage_3/run_config.yml

--- a/example/grid_search_example/run_config.yml
+++ b/example/grid_search_example/run_config.yml
@@ -1,14 +1,15 @@
 run_configuration:
   type: train # train, warmstart
   config:
-    num_epochs: 10 # Number of epochs
+    num_epochs: 50 # Number of epochs
+    num_batches_per_epoch: 100
     gs_config_path: /scratch/max/mlgym/example/grid_search_example/gs_config.yml
 
 environment:
   type: multiprocessing # multiprocessing,  main_process, accelerate
   config:
     process_count: 1 # Max. number of processes running at a time.
-    computation_device_ids: [4] # Indices of GPUs to distribute the GS over
+    computation_device_ids: [5] # Indices of GPUs to distribute the GS over
 
 logging:
   websocket_logging_servers: # List of websocket logging servers, e.g., http://127.0.0.1:9090 http://127.0.0.1:8080

--- a/example/grid_search_example/run_config.yml
+++ b/example/grid_search_example/run_config.yml
@@ -8,8 +8,8 @@ run_configuration:
 environment:
   type: multiprocessing # multiprocessing,  main_process, accelerate
   config:
-    process_count: 1 # Max. number of processes running at a time.
-    computation_device_ids: [5] # Indices of GPUs to distribute the GS over
+    process_count: 3 # Max. number of processes running at a time.
+    computation_device_ids: [0, 1, 5] # Indices of GPUs to distribute the GS over
 
 logging:
   websocket_logging_servers: # List of websocket logging servers, e.g., http://127.0.0.1:9090 http://127.0.0.1:8080

--- a/example/grid_search_example/train_gs_mnist_conv_net_websocket.sh
+++ b/example/grid_search_example/train_gs_mnist_conv_net_websocket.sh
@@ -2,9 +2,4 @@
 #!/bin/sh
 
 
-python run.py --process_count 21 \
-              --num_epochs 100 \
-              --websocket_logging_servers http://127.0.0.1:5002 \
-              --gs_rest_api_endpoint http://127.0.0.1:5001 \
-              train \
-              --gs_config_path gs_config.yml
+python run.py --config_path run_config.yml

--- a/src/ml_board/README.md
+++ b/src/ml_board/README.md
@@ -76,6 +76,7 @@ _GET /grid_searches/<grid_search_id>/experiments_
 
 TODO need to check "experiments" in URL
 
+TODO need to check "experiments" in URL  
 ```json
 [
     {
@@ -156,6 +157,17 @@ Delete specific Checkpoint Resource:
 _DELETE /checkpoints/<grid_search_id><experiment_id>/<checkpoint_id>/<checkpoint_resource>_
 
 _Ex: DELETE /checkpoints/2023-04-12--23-42-17/0/0/model_
+
+*PUT /checkpoints/<grid_search_id><experiment_id>/<checkpoint_id>/<model, optimizer, lr_scheduler, stateful_component>*
+```json
+{
+        "<model, optimizer, lr_scheduler, stateful_component>": <binary stream>,
+        "chunk_id": <chunk_id>,
+        "num_chunks": <num_chunks>
+```
+
+*DELETE /checkpoints/<grid_search_id><experiment_id>/<checkpoint_id>*
+
 
 ## Websocket API
 
@@ -283,6 +295,12 @@ metric scores of a model at a specific epoch.
 ```
 
 # Implementation idea:
+
+**Checkpointing (legacy)**:
+
+After each epoch and if condition is fulfilled (based on strategy), the model is binarized and sent to the server as a checkpoint.
+
+Create checkpoint:
 
 Add subscribers to trainer, evaluator and gymjob. We need to inject them via
 For trainer and evaluator we add the subscribers within the blueprints. E.g., trainer.add_subscriber(subscriber)

--- a/src/ml_board/backend/restful_api/data_access.py
+++ b/src/ml_board/backend/restful_api/data_access.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 from ml_gym.error_handling.exception import InvalidPathError
 import json
 from ml_board.backend.restful_api.data_models import RawTextFile, CheckpointResource, ExperimentStatus
+from pyparsing import Generator
 
 
 class DataAccessIF(ABC):
@@ -17,49 +18,53 @@ class DataAccessIF(ABC):
     """
 
     @abstractmethod
-    def get_experiment_statuses(self, grid_search_id: str):
+    def get_experiment_statuses(self, grid_search_id: str) -> List[ExperimentStatus]:
         raise NotImplementedError
 
     @abstractmethod
-    def add_raw_config_to_grid_search(self, grid_search_id: str, config_name: str, config_file: RawTextFile):
+    def add_raw_config_to_grid_search(self, grid_search_id: str, config_name: str, config_file: RawTextFile) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def add_config_to_experiment(self, grid_search_id: str, experiment_id: str, config_name: str, config: RawTextFile):
+    def add_config_to_experiment(self, grid_search_id: str, experiment_id: str, config_name: str, config: RawTextFile) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def get_grid_config(self, grid_search_id: str, config_name: str):
+    def get_grid_config(self, grid_search_id: str, config_name: str) -> Generator:
         raise NotImplementedError
 
     @abstractmethod
-    def get_experiment_config(self, grid_search_id: str, experiment_id: str, config_name: str):
+    def get_experiment_config(self, grid_search_id: str, experiment_id: str, config_name: str) -> Generator:
         raise NotImplementedError
 
     @abstractmethod
-    def get_checkpoint_list(self, grid_search_id: str, experiment_id: str):
+    def get_checkpoint_list(self, grid_search_id: str, experiment_id: str) -> List[Dict]:
         raise NotImplementedError
 
     @abstractmethod
-    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource):
+    def get_checkpoint_resource(
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
+    ) -> Generator:
         raise NotImplementedError
 
     @abstractmethod
     def add_checkpoint_resource(
         self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource, payload_pickle: bytes
-    ):
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def delete_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource):
+    def delete_checkpoint_resource(
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def delete_checkpoints(self, grid_search_id: str, experiment_id: str, epoch: str):
+    def delete_checkpoints(self, grid_search_id: str, experiment_id: str, epoch: str) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def get_checkpoint_dict_epoch(self, grid_search_id: str, experiment_id: str, epoch: str):
+    def get_checkpoint_dict_epoch(self, grid_search_id: str, experiment_id: str, epoch: str) -> List[Dict]:
         raise NotImplementedError
 
 
@@ -155,7 +160,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def add_raw_config_to_grid_search(self, grid_search_id: str, config_name: str, config_file: RawTextFile):
+    def add_raw_config_to_grid_search(self, grid_search_id: str, config_name: str, config_file: RawTextFile) -> None:
         """
         Add Config for a Grid Search ID to event storage
 
@@ -174,7 +179,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def add_config_to_experiment(self, grid_search_id: str, experiment_id: str, config_name: str, config: RawTextFile):
+    def add_config_to_experiment(self, grid_search_id: str, experiment_id: str, config_name: str, config: RawTextFile) -> None:
         """
         Add experiment config given the experiment ID & grid search ID to event storage.
 
@@ -197,7 +202,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def get_grid_config(self, grid_search_id: str, config_name: str):
+    def get_grid_config(self, grid_search_id: str, config_name: str) -> Generator:
         """
         Fetch grid config for a Grid Search ID from the event storage.
 
@@ -217,7 +222,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def get_experiment_config(self, grid_search_id: str, experiment_id: str, config_name: str):
+    def get_experiment_config(self, grid_search_id: str, experiment_id: str, config_name: str) -> Generator:
         """
         `Fetch experiment config given the experiment ID & grid search ID from event storage.
 
@@ -240,7 +245,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def get_checkpoint_dict_epoch(self, grid_search_id: str, experiment_id: str, epoch: str):
+    def get_checkpoint_dict_epoch(self, grid_search_id: str, experiment_id: str, epoch: str) -> List[Dict]:
         """
         Fetch all checkpoint resource pickle file names from event storage
         given the epoch, experiment ID & grid search ID.
@@ -269,7 +274,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def get_checkpoint_list(self, grid_search_id: str, experiment_id):
+    def get_checkpoint_list(self, grid_search_id: str, experiment_id) -> List[Dict]:
         """
         `Fetch all checkpoint resource pickle file names given the experiment ID & grid search ID from event storage.
 
@@ -303,7 +308,9 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource):
+    def get_checkpoint_resource(
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
+    ) -> Generator:
         """
         `Fetch checkpoint resource pickle file given the experiment ID & grid search ID from event storage.
 
@@ -329,7 +336,7 @@ class FileDataAccess(DataAccessIF):
 
     def add_checkpoint_resource(
         self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource, payload_pickle: bytes
-    ):
+    ) -> None:
         """
         Add a checkpoint resource pickle file given the epoch, experiment ID & grid search ID to event storage.
 
@@ -354,7 +361,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def delete_checkpoints(self, grid_search_id: str, experiment_id: str, epoch: str):
+    def delete_checkpoints(self, grid_search_id: str, experiment_id: str, epoch: str) -> None:
         """
         Delete checkpoint FOLDER From the event storage
         given the epoch, experiment ID & grid search ID.
@@ -374,7 +381,9 @@ class FileDataAccess(DataAccessIF):
         else:
             raise FileNotFoundError(f"Folder in path {requested_full_path} not found.")
 
-    def delete_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource):
+    def delete_checkpoint_resource(
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
+    ) -> None:
         """
         Delete checkpoint resource pickle file from the event storage
         given the epoch, experiment ID & grid search ID.

--- a/src/ml_board/backend/restful_api/data_access.py
+++ b/src/ml_board/backend/restful_api/data_access.py
@@ -53,8 +53,7 @@ class DataAccessIF(ABC):
 
     @abstractmethod
     def delete_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: str
-    ) -> None:
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: str) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -265,7 +264,7 @@ class FileDataAccess(DataAccessIF):
             files = FileDataAccess.get_checkpoint_files(requested_full_path, base_path=self.top_level_logging_path)
             for file_num in range(len(files)):
                 split = os.path.normpath(files[file_num]).split(os.sep)
-                checkpoints.append(os.path.basename(split[-1]).split(".")[0])
+                checkpoints.append(os.path.basename(split[-1]))
             response.append({"experiment_id": experiment_id, "epoch": epoch, "checkpoints": checkpoints})
             return response
 
@@ -296,9 +295,9 @@ class FileDataAccess(DataAccessIF):
                     response.append({"experiment_id": experiment_id, "epoch": last_epoch, "checkpoints": checkpoints})
                     last_epoch = epoch
                     checkpoints = []
-                    checkpoints.append(os.path.basename(split[-1]).split(".")[0])
+                    checkpoints.append(os.path.basename(split[-1]))
                 else:
-                    checkpoints.append(os.path.basename(split[-1]).split(".")[0])
+                    checkpoints.append(os.path.basename(split[-1]))
 
             response.append({"experiment_id": experiment_id, "epoch": epoch, "checkpoints": checkpoints})
             return response

--- a/src/ml_board/backend/restful_api/data_access.py
+++ b/src/ml_board/backend/restful_api/data_access.py
@@ -4,6 +4,7 @@ import glob
 import re
 import shutil
 from typing import Dict, List
+from fastapi import UploadFile
 from ml_gym.error_handling.exception import InvalidPathError
 import json
 from ml_board.backend.restful_api.data_models import RawTextFile, CheckpointResource, ExperimentStatus
@@ -42,20 +43,17 @@ class DataAccessIF(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
-    ) -> Generator:
+    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str,
+                                checkpoint_resource: str) -> Generator:
         raise NotImplementedError
 
     @abstractmethod
-    def add_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource, payload_pickle: bytes
-    ) -> None:
+    def add_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_file: UploadFile) -> None:
         raise NotImplementedError
 
     @abstractmethod
     def delete_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: str
     ) -> None:
         raise NotImplementedError
 
@@ -309,7 +307,7 @@ class FileDataAccess(DataAccessIF):
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
     def get_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
+        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: str
     ) -> Generator:
         """
         `Fetch checkpoint resource pickle file given the experiment ID & grid search ID from event storage.
@@ -318,13 +316,12 @@ class FileDataAccess(DataAccessIF):
              grid_search_id (str): Grid Search ID
              experiment_id (str): Experiment ID
              epoch (str): Epoch number
-             checkpoint_resource (CheckpointResource) : CheckpointResource type
+             checkpoint_resource (str) : name of the checkpoint resource file
 
         :returns: bytes response of pickle file
         """
-        requested_full_path = os.path.realpath(
-            os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id), str(epoch), f"{checkpoint_resource}.pickle")
-        )
+        requested_full_path = os.path.realpath(os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id),
+                                                            str(epoch), checkpoint_resource))
         if FileDataAccess.is_safe_path(base_dir=self.top_level_logging_path, requested_path=requested_full_path):
             if not os.path.isfile(requested_full_path):
                 raise InvalidPathError(f"Resource {requested_full_path} not found.")
@@ -334,9 +331,7 @@ class FileDataAccess(DataAccessIF):
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
-    def add_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource, payload_pickle: bytes
-    ) -> None:
+    def add_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_file: UploadFile) -> None:
         """
         Add a checkpoint resource pickle file given the epoch, experiment ID & grid search ID to event storage.
 
@@ -344,20 +339,18 @@ class FileDataAccess(DataAccessIF):
              grid_search_id (str): Grid Search ID
              experiment_id (str): Experiment ID
              epoch (str): Epoch number
-             checkpoint_resource (CheckpointResource) : CheckpointResource type
-             payload_pickle (bytes): Pickle file to be added
+             checkpoint_file (UploadFile): file to be uploaded
 
         :returns: Pickle file Stream response
         """
-
-        requested_full_path = os.path.realpath(
-            os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id), str(epoch), f"{checkpoint_resource}.pickle")
-        )
+        file_name = checkpoint_file.filename
+        file_path = os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id), str(epoch), file_name)
+        requested_full_path = os.path.realpath(file_path)
 
         if FileDataAccess.is_safe_path(base_dir=self.top_level_logging_path, requested_path=requested_full_path):
             os.makedirs(os.path.dirname(requested_full_path), exist_ok=True)
             with open(requested_full_path, "wb") as fd:
-                fd.write(payload_pickle)
+                shutil.copyfileobj(checkpoint_file.file, fd)
         else:
             raise InvalidPathError(f"File path {requested_full_path} is not safe.")
 
@@ -372,18 +365,16 @@ class FileDataAccess(DataAccessIF):
              epoch (str): Epoch number
         """
 
-        requested_full_path = os.path.realpath(
-            os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id), str(epoch))
-        )
+        requested_full_path = os.path.realpath(os.path.join(self.top_level_logging_path, str(grid_search_id),
+                                                            str(experiment_id), str(epoch)))
 
         if FileDataAccess.is_safe_path(base_dir=self.top_level_logging_path, requested_path=requested_full_path):
             shutil.rmtree(requested_full_path)
         else:
-            raise FileNotFoundError(f"Folder in path {requested_full_path} not found.")
+            raise InvalidPathError(f"The path {requested_full_path} is not safe.")
 
-    def delete_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource
-    ) -> None:
+    def delete_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str,
+                                   checkpoint_resource: str) -> None:
         """
         Delete checkpoint resource pickle file from the event storage
         given the epoch, experiment ID & grid search ID.
@@ -392,17 +383,16 @@ class FileDataAccess(DataAccessIF):
              grid_search_id (str): Grid Search ID
              experiment_id (str): Experiment ID
              epoch (str): Epoch number
-             checkpoint_resource (CheckpointResource) : CheckpointResource type
+             checkpoint_resource (str): name of the checkpoint resource file
         """
 
         folder_path = os.path.realpath(os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id), str(epoch)))
-        requested_full_path = os.path.realpath(
-            os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id), str(epoch), f"{checkpoint_resource}.pickle")
-        )
+        requested_full_path = os.path.realpath(os.path.join(self.top_level_logging_path, str(grid_search_id), str(experiment_id),
+                                                            str(epoch), checkpoint_resource))
 
         if FileDataAccess.is_safe_path(base_dir=self.top_level_logging_path, requested_path=requested_full_path):
             os.remove(requested_full_path)
             if len([name for name in os.listdir(folder_path) if os.path.isfile(os.path.join(folder_path, name))]) == 0:
                 os.rmdir(folder_path)
         else:
-            raise FileNotFoundError(f"File in path {requested_full_path} not found.")
+            raise InvalidPathError(f"Path {requested_full_path} is not safe.")

--- a/src/ml_board/backend/restful_api/data_models.py
+++ b/src/ml_board/backend/restful_api/data_models.py
@@ -19,6 +19,7 @@ class ExperimentStatus(BaseModel):
     experiment_config: Dict
 
 
+# TODO Check if Enum is still needed
 class CheckpointResource(str, Enum):
     model = "model"
     optimizer = "optimizer"

--- a/src/ml_board/backend/restful_api/data_models.py
+++ b/src/ml_board/backend/restful_api/data_models.py
@@ -24,3 +24,4 @@ class CheckpointResource(str, Enum):
     optimizer = "optimizer"
     lr_scheduler = "lr_scheduler"
     stateful_components = "stateful_components"
+    accelerate = "accelerate_zip"

--- a/src/ml_board/backend/restful_api/restful_api_server.py
+++ b/src/ml_board/backend/restful_api/restful_api_server.py
@@ -229,7 +229,7 @@ class RestfulAPIServer:
         except InvalidPathError as e:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Provided invalid parameters for checkpoint resource.") from e
 
-    def delete_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource):
+    def delete_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: str):
         """
         ``HTTP DELETE`` Delete checkpoint resource pickle file
           given the epoch, experiment ID & grid search ID.
@@ -238,7 +238,7 @@ class RestfulAPIServer:
              grid_search_id (str): Grid Search ID
              experiment_id (str): Experiment ID
              epoch (str): Epoch number
-             checkpoint_resource (CheckpointResource) : CheckpointResource type
+             checkpoint_resource (str) : Name oif the checkpoint resource
         """
         try:
             self.data_access.delete_checkpoint_resource(grid_search_id=grid_search_id, experiment_id=experiment_id,
@@ -278,10 +278,8 @@ class RestfulAPIServer:
              grid_search_id (str): Grid Search ID
              experiment_id (str): Experiment ID
              epoch (str): Epoch number
-             checkpoint_resource (CheckpointResource) : CheckpointResource type
-             file (bytes): Pickle file to be added
+             checkpoint_file (UploadFile): binary file to be added
 
-        :returns: Pickle file Stream response
         """
         try:
             self.data_access.add_checkpoint_resource(grid_search_id=grid_search_id,

--- a/src/ml_board/backend/restful_api/restful_api_server.py
+++ b/src/ml_board/backend/restful_api/restful_api_server.py
@@ -1,5 +1,4 @@
-import base64
-from fastapi import FastAPI, File
+from fastapi import FastAPI, UploadFile
 from fastapi import status, HTTPException
 from fastapi.responses import StreamingResponse
 from ml_board.backend.restful_api.data_access import DataAccessIF
@@ -45,7 +44,7 @@ class RestfulAPIServer:
             endpoint=self.get_checkpoint_resource,
         )
         self.app.add_api_route(
-            path="/checkpoints/{grid_search_id}/{experiment_id}/{epoch}/{checkpoint_resource}",
+            path="/checkpoints/{grid_search_id}/{experiment_id}/{epoch}",
             methods=["POST"],
             endpoint=self.add_checkpoint_resource,
         )
@@ -208,7 +207,7 @@ class RestfulAPIServer:
                 status_code=status.HTTP_403_FORBIDDEN, detail="Provided invalid parameters for fetching checkpoint list."
             ) from e
 
-    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource):
+    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: str):
         """
         ``HTTP GET`` Fetch checkpoint resource pickle file
           given the experiment ID & grid search ID.
@@ -242,12 +241,14 @@ class RestfulAPIServer:
              checkpoint_resource (CheckpointResource) : CheckpointResource type
         """
         try:
-            self.data_access.delete_checkpoint_resource(
-                grid_search_id=grid_search_id, experiment_id=experiment_id, epoch=epoch, checkpoint_resource=checkpoint_resource
-            )
-
+            self.data_access.delete_checkpoint_resource(grid_search_id=grid_search_id, experiment_id=experiment_id,
+                                                        epoch=epoch, checkpoint_resource=checkpoint_resource)
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                detail=f"Checkpoint resource {grid_search_id}/{experiment_id}/{epoch}/{checkpoint_resource} not found.") from e
         except InvalidPathError as e:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Provided invalid parameters for checkpoint resource.") from e
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
+                                detail=f"Provided invalid parameters for checkpoint resource {grid_search_id}/{experiment_id}/{epoch}/{checkpoint_resource}.") from e
 
     def delete_checkpoints(self, grid_search_id: str, experiment_id: str, epoch: str):
         """
@@ -261,13 +262,14 @@ class RestfulAPIServer:
         """
         try:
             self.data_access.delete_checkpoints(grid_search_id=grid_search_id, experiment_id=experiment_id, epoch=epoch)
-
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                detail=f"Checkpoint resource {grid_search_id}/{experiment_id}/{epoch} not found.") from e
         except InvalidPathError as e:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Provided invalid parameters for checkpoint resource.") from e
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
+                                detail=f"Provided invalid parameters for checkpoint resource {grid_search_id}/{experiment_id}/{epoch}.") from e
 
-    def add_checkpoint_resource(
-        self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_resource: CheckpointResource, file: bytes = File(...)
-    ):
+    def add_checkpoint_resource(self, grid_search_id: str, experiment_id: str, epoch: str, checkpoint_file: UploadFile):
         """
         ``HTTP POST`` Add a checkpoint resource pickle file
           given the epoch, experiment ID & grid search ID.
@@ -282,19 +284,14 @@ class RestfulAPIServer:
         :returns: Pickle file Stream response
         """
         try:
-            payload_pickle = base64.b64decode(file)
-            self.data_access.add_checkpoint_resource(
-                grid_search_id=grid_search_id,
-                experiment_id=experiment_id,
-                epoch=epoch,
-                checkpoint_resource=checkpoint_resource,
-                payload_pickle=payload_pickle,
-            )
+            self.data_access.add_checkpoint_resource(grid_search_id=grid_search_id,
+                                                     experiment_id=experiment_id,
+                                                     epoch=epoch,
+                                                     checkpoint_file=checkpoint_file)
         except InvalidPathError as e:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Provided invalid payload or grid_search_id {grid_search_id}, experiment_id {experiment_id} or epoch {epoch}.",
-            ) from e
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
+                                detail=f"Provided invalid payload or grid_search_id {grid_search_id}, experiment_id {experiment_id} or epoch {epoch}.",
+                                ) from e
 
     def run_server(self, application_server_callable: Callable):
         application_server_callable(app=self.app)

--- a/src/ml_gym/gym/evaluators/accelerate_evaluator.py
+++ b/src/ml_gym/gym/evaluators/accelerate_evaluator.py
@@ -21,7 +21,7 @@ class AccelerateEvaluator(AbstractEvaluator):
 
     def evaluate(self, model: NNModel, accelerator: Accelerator, epoch_result_callback_fun: Callable = None,
                  batch_processed_callback_fun: Callable = None) -> List[EvaluationBatchResult]:
-        model = model.eval()
+        model.eval()
 
         # returns a EvaluationBatchResult for each split
         evaluation_batch_results = self.eval_component.evaluate(model=model, accelerator=accelerator,

--- a/src/ml_gym/gym/gym.py
+++ b/src/ml_gym/gym/gym.py
@@ -20,6 +20,7 @@ class Gym(ABC):
     def __init__(self, logger_collection_constructable: MLgymStatusLoggerCollectionConstructable):
         self.job_status_logger = JobStatusLogger(logger_collection_constructable.construct())
 
+
     @abstractmethod
     def run(self, blueprints: List[BluePrint]):
         """Executes the jobs. Note that this function blocks until all jobs have been executed!
@@ -126,6 +127,7 @@ class GymFactory:
                                                            logger_collection_constructable=logger_collection_constructable,
                                                            gs_restful_api_client_constructable=gs_restful_api_client_constructable,
                                                            num_batches_per_epoch=num_batches_per_epoch)
+
         return gym_job.execute(device=device)
 
     @staticmethod

--- a/src/ml_gym/gym/gym_jobs/accelerate_gym_job.py
+++ b/src/ml_gym/gym/gym_jobs/accelerate_gym_job.py
@@ -57,24 +57,28 @@ class AccelerateGymJob(AbstractGymJob):
         self.optimizer.register_model_params(model_params=dict(self.model.named_parameters()))
         self.lr_scheduler.register_optimizer(optimizer=self.optimizer)
 
-        self.model, self.optimizer, self.trainer, self.evaluator, self.lr_scheduler, train_loader = self.accelerator.prepare(self.model,
-                                                                                                                             self.optimizer,
-                                                                                                                             self.trainer,
-                                                                                                                             self.evaluator,
-                                                                                                                             self.lr_scheduler,
-                                                                                                                             self.trainer.train_loader)
+        eval_loader_keys, eval_loaders_list = zip(*self.evaluator.eval_component.dataset_loaders.items())
+
+        self.model, self.optimizer, self.lr_scheduler, train_loader, *eval_acc_loaders_list = self.accelerator.prepare(self.model,
+                                                                                                                       self.optimizer,
+                                                                                                                       self.lr_scheduler,
+                                                                                                                       self.trainer.train_loader,
+                                                                                                                       *eval_loaders_list)
+
+        eval_loaders = {k: v for k, v in zip(eval_loader_keys, eval_acc_loaders_list)}
+
         self.trainer.train_loader = DatasetLoaderFactory.get_data_loader_shard_wrapper(data_loader_shard=train_loader,
                                                                                        dataset_name=self.trainer.train_loader.dataset_name,
                                                                                        dataset_tag=self.trainer.train_loader.dataset_tag)
 
         self.evaluator.eval_component.dataset_loaders = {key: DatasetLoaderFactory.get_data_loader_shard_wrapper(
-            data_loader_shard=self.accelerator.prepare(data_loader),
+            data_loader_shard=eval_loaders[key],
             dataset_name=data_loader.dataset_name,
             dataset_tag=data_loader.dataset_tag) for key, data_loader in self.evaluator.eval_component.dataset_loaders.items()}
 
         partial_batch_done_callback = partial(self.batch_processed_callback, experiment_status_logger=self._experiment_status_logger)
         def evaluation_step_routine(current_epoch: int): return self._evaluation_step(current_epoch=current_epoch)
-        partial_train_epoch_done_callback = partial(self.train_epoch_done_callback, evaluation_step_routine=evaluation_step_routine, 
+        partial_train_epoch_done_callback = partial(self.train_epoch_done_callback, evaluation_step_routine=evaluation_step_routine,
                                                     accelerator=self.accelerator)
 
         model = self.trainer.train(num_epochs=self.num_epochs, model=self.model, optimizer=self.optimizer,

--- a/src/ml_gym/gym/gym_jobs/gym_job.py
+++ b/src/ml_gym/gym/gym_jobs/gym_job.py
@@ -1,5 +1,8 @@
 from abc import abstractmethod
+import os
+import pickle
 from typing import Callable, List
+from ml_board.backend.restful_api.data_models import CheckpointResource
 from ml_gym.batching.batch import EvaluationBatchResult
 from ml_gym.checkpointing.checkpointing import CheckpointingIF, CheckpointingInstruction
 from ml_gym.early_stopping.early_stopping_strategies import EarlyStoppingIF
@@ -16,6 +19,7 @@ from ml_gym.persistency.io import GridSearchAPIClientIF
 from ml_gym.persistency.logging import ExperimentStatusLogger
 import torch
 from accelerate import Accelerator
+import shutil
 
 
 class AbstractGymJob(StatefulComponent):
@@ -60,29 +64,43 @@ class AbstractGymJob(StatefulComponent):
     def execute(self, device: torch.device):
         raise NotImplementedError
 
-    def run_checkpointing(self, checkpoint_instruction: CheckpointingInstruction, current_epoch: int):
+    def run_checkpointing(self, checkpoint_instruction: CheckpointingInstruction, current_epoch: int, accelerator: Accelerator = None):
         """
         Create and delete checkpoints for each epoch in experiments.
 
         :params:
             checkpoint_instruction: CheckpointingInstruction object
         """
-
         if checkpoint_instruction.save_current:
-            payload_dict = {
-                "epoch": current_epoch,
-                "model": self.model.state_dict(),
-                "optimizer": self.optimizer.state_dict(),
-                "lr_scheduler": self.lr_scheduler.state_dict(),
-                "stateful_components": self.get_state(),
-            }
 
-            self.gs_api_client.add_checkpoint_resource(
-                grid_search_id=self.grid_search_id, experiment_id=self.experiment_id, payload=payload_dict
-            )
+            if accelerator is not None:
+                root_dir = f"/root/checkpoints/{current_epoch}"
+                global_rank = accelerator.process_index
+                checkpoint_file_name = f"checkpoint_rank_{global_rank}"
+                checkpoint_path = os.path.join(root_dir, f"rank_{global_rank}/")
+                accelerator.save_state(output_dir=checkpoint_path)
+                shutil.make_archive(base_name=os.path.join(root_dir, checkpoint_file_name), format='zip', root_dir=checkpoint_path)
+                with open(os.path.join(root_dir, f"{checkpoint_file_name}.zip"), 'rb') as fd:
+                    self.gs_api_client.add_checkpoint_resource(grid_search_id=self.grid_search_id, experiment_id=self.experiment_id,
+                                                               epoch=current_epoch, payload_stream=fd,
+                                                               custom_file_name=f"{checkpoint_file_name}.zip")
 
-        for epoch in checkpoint_instruction.checkpoints_to_delete:
-            self.gs_api_client.delete_checkpoints(grid_search_id=self.grid_search_id, experiment_id=self.experiment_id, epoch=epoch)
+            else:
+                payload_dict = {
+                    CheckpointResource.model: pickle.dumps(self.model.state_dict()),
+                    CheckpointResource.optimizer: pickle.dumps(self.optimizer.state_dict()),
+                    CheckpointResource.lr_scheduler: pickle.dumps(self.lr_scheduler.state_dict()),
+                    CheckpointResource.stateful_components: pickle.dumps(self.get_state())
+                }
+
+                for checkpoint_resource_key, checkpoint_resource_stream in payload_dict.items():
+                    self.gs_api_client.add_checkpoint_resource(grid_search_id=self.grid_search_id, experiment_id=self.experiment_id,
+                                                               epoch=current_epoch, payload_stream=checkpoint_resource_stream,
+                                                               custom_file_name=checkpoint_resource_key)
+
+        if accelerator is not None and accelerator.is_main_process:
+            for epoch in checkpoint_instruction.checkpoints_to_delete:
+                self.gs_api_client.delete_checkpoints(grid_search_id=self.grid_search_id, experiment_id=self.experiment_id, epoch=epoch)
 
     @staticmethod
     def batch_processed_callback(status: str, experiment_status_logger: ExperimentStatusLogger, num_batches: int,
@@ -106,11 +124,11 @@ class AbstractGymJob(StatefulComponent):
         evaluation_results = evaluation_step_routine(current_epoch=current_epoch)
         if current_epoch > 0:
             self.lr_scheduler.step()
-        if accelerator is None or accelerator is not None and accelerator.is_main_process:
-            checkpointing_instruction = self.checkpointing_strategy.get_model_checkpoint_instruction(num_epochs=num_epochs,
-                                                                                                     current_epoch=current_epoch,
-                                                                                                     evaluation_result=evaluation_results)
-            self.run_checkpointing(checkpointing_instruction, current_epoch=current_epoch)
+        checkpointing_instruction = self.checkpointing_strategy.get_model_checkpoint_instruction(num_epochs=num_epochs,
+                                                                                                 current_epoch=current_epoch,
+                                                                                                 evaluation_result=evaluation_results)
+        self.run_checkpointing(checkpointing_instruction, current_epoch=current_epoch, accelerator=accelerator)
+
         if self.early_stopping_strategy.is_stopping_criterion_fulfilled(current_epoch=current_epoch,
                                                                         evaluation_results=evaluation_results):
             raise EarlyStoppingCriterionFulfilledError

--- a/src/ml_gym/gym/trainers/accelerate_trainer.py
+++ b/src/ml_gym/gym/trainers/accelerate_trainer.py
@@ -49,6 +49,8 @@ class AccelerateTrainComponent(StatefulComponent):
               accelerator: Accelerator, batch_done_callback_fun: Callable, epoch_done_callback_fun: Callable,
               num_epochs: int, num_batches_per_epoch: int = None) -> NNModel:
 
+        model.train()
+
         if num_batches_per_epoch is None:
             num_batches_per_epoch = len(dataloader)
 
@@ -69,7 +71,7 @@ class AccelerateTrainComponent(StatefulComponent):
                                         current_epoch=current_epoch)
             if (batch_id + 1) % num_batches_per_epoch == 0:  # when epoch done
                 epoch_done_callback_fun(num_epochs=num_epochs, current_epoch=current_epoch, model=model, accelerator=accelerator)
-
+                model.train()
         return model
 
     def calc_loss(self, model: NNModel, batch: DatasetBatch) -> torch.Tensor:
@@ -86,8 +88,6 @@ class AccelerateTrainer:
     def train(self, num_epochs: int, model: NNModel, optimizer: OptimizerAdapter,
               batch_done_callback_fun: Callable, epoch_done_callback: Callable, accelerator: Accelerator,
               num_batches_per_epoch: int = None) -> NNModel:
-
-        model = model.train()
 
         # accelerate_train_loader = accelerator.prepare(self.train_loader)
 

--- a/src/ml_gym/gym/trainers/standard_trainer.py
+++ b/src/ml_gym/gym/trainers/standard_trainer.py
@@ -31,6 +31,7 @@ class TrainComponent(StatefulComponent):
     def train(self, model: NNModel, optimizer: OptimizerAdapter, dataloader: DatasetLoader, device: torch.device,
               batch_done_callback_fun: Callable, epoch_done_callback_fun: Callable,
               num_epochs: int, num_batches_per_epoch: int = None) -> NNModel:
+        model.train()
 
         if num_batches_per_epoch is None:
             num_batches_per_epoch = len(dataloader)
@@ -54,6 +55,7 @@ class TrainComponent(StatefulComponent):
 
             if (batch_id + 1) % num_batches_per_epoch == 0:  # when epoch done
                 epoch_done_callback_fun(num_epochs=num_epochs, current_epoch=current_epoch, model=model)
+                model.train()
 
         return model
 
@@ -72,7 +74,6 @@ class Trainer:
               batch_done_callback_fun: Callable, epoch_done_callback: Callable,
               num_batches_per_epoch: int = None) -> NNModel:
 
-        model = model.train()
 
         model = self.train_component.train(model=model, optimizer=optimizer, dataloader=self.train_loader, device=device,
                                            batch_done_callback_fun=batch_done_callback_fun, epoch_done_callback_fun=epoch_done_callback,

--- a/src/ml_gym/persistency/io.py
+++ b/src/ml_gym/persistency/io.py
@@ -25,7 +25,7 @@ class GridSearchAPIClientIF(ABC):
     def get_validation_config(self, grid_search_id: str):
         raise NotImplementedError
 
-    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, checkpoint_id: int, checkpoint_resource: CheckpointResource):
+    def get_checkpoint_resource(self, grid_search_id: str, experiment_id: str, checkpoint_id: int, checkpoint_resource: str):
         raise NotImplementedError
 
     def add_checkpoint_resource(self, grid_search_id: str, experiment_id: str, payload: Dict, custom_file_name: str):
@@ -95,6 +95,7 @@ class GridSearchRestfulAPIClient(GridSearchAPIClientIF):
 
         :params:
              url (str): HTTP request URL
+             file_name (str): Name of the file to be posted
              payload (bytes); pickle dump to be sent
         """
         response = requests.post(url=url, files={"checkpoint_file": (file_name, payload_stream)})
@@ -144,9 +145,8 @@ class GridSearchRestfulAPIClient(GridSearchAPIClientIF):
     #     url = f"{self.endpoint}/grid_searches/{grid_search_id}/gs_config"
     #     return GridSearchRestfulAPIClient._put_raw_text_file_resource(url, grid_search_config)
 
-    def add_config_string(
-        self, grid_search_id: str, config_name: str, config: str, file_format: FileFormat, experiment_id: int = None
-    ) -> Dict:
+    def add_config_string(self, grid_search_id: str, config_name: str, config: str, file_format: FileFormat,
+                          experiment_id: int = None) -> Dict:
         """
         ``HTTP PUT Call Request`` Add configuration
           given the grid search ID over HTTP call.
@@ -231,7 +231,8 @@ class GridSearchRestfulAPIClient(GridSearchAPIClientIF):
         :params:
              grid_search_id (str): Grid Search ID
              experiment_id (str): Experiment ID
-             payload (bytes): Bytes stream containing CheckpointResource 
+             epoch (int): Current epoch
+             payload_stream (bytes): Bytes stream containing CheckpointResource 
              custom_file_name (str): File name of the checkpoint resource
         """
 

--- a/src/ml_gym/util/devices.py
+++ b/src/ml_gym/util/devices.py
@@ -6,7 +6,7 @@ os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 
 
 def get_devices(gpu_device_ids: List[int] = None) -> List[torch.device]:
-    if gpu_device_ids is None:
+    if gpu_device_ids is None or not gpu_device_ids:
         print("WARNING: No cuda devices specified. Falling back to CPUs.")   # TODO Introduce proper logging...
         return [torch.device("cpu")]
     if torch.cuda.is_available():  # if we got some GPUs
@@ -14,7 +14,3 @@ def get_devices(gpu_device_ids: List[int] = None) -> List[torch.device]:
     else:
         print("WARNING: No cuda devices available. Falling back to CPUs.")   # TODO Introduce proper logging...
         return [torch.device("cpu")]
-
-
-if __name__ == "__main__":
-    print(get_devices())

--- a/src/setup.py
+++ b/src/setup.py
@@ -35,7 +35,8 @@ setup(
         "flask-socketio",
         "datasets",
         "transformers",
-        "accelerate"
+        "accelerate",
+        "fs"
     ],
     python_requires=">=3.7",
     include_package_data=True,


### PR DESCRIPTION
* added deepspeed support (zero stage 3) including checkpointing
* refactored checkpointing API to upload arbitrary files (not just model, optimizer etc.) deepspeed has its own checkpoint structure, so we zip it up and send it to the server via the refactored checkpointing API
* the examples starter scripts for cnn_ddp, cnn_zero_stage_3 and grid_search_example have been fixed to run with the new structure